### PR TITLE
detection for forsys-shiny data and logic to prevent extra run

### DIFF
--- a/R/ForSys.R
+++ b/R/ForSys.R
@@ -50,6 +50,7 @@ run <- function(
     scenario_name = '',
     num_reps = 1,
     scenario_stand_filename = '',
+    shiny_data = '',
     stand_id_field = '',
     stand_pcp_spm = NULL,
     stand_filter = NULL,
@@ -115,7 +116,14 @@ run <- function(
     # !!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     # # # Load data
-    stands <- load_dataset(scenario_stand_filename)
+    if (!is.null(shiny_data)){
+      message("Forsys Shiny data detected.")
+      stands <- shiny_data
+    }else{
+      message("No Forsys Shiny data detected.")
+      stands <- load_dataset(scenario_stand_filename)
+    }
+
     if(!is.null(fire_intersect_table)) fires <- fire_intersect_table
 
     # Calculate SPM & PCP values ## TODO check add_target_field names after merge

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -10,6 +10,7 @@ run(
   scenario_name = "",
   num_reps = 1,
   scenario_stand_filename = "",
+  shiny_data = "",
   stand_id_field = "",
   stand_pcp_spm = NULL,
   stand_filter = NULL,


### PR DESCRIPTION
Changelog:

Description: Added compatibility to forsys-shiny's latest data push, which now prevents duplicate load_dataset calls and works much more efficiently. If forsys-shiny is not what invokes forsysr, then the logic is still available to load datasets via filename.