### PR TITLE
adding naming for scenario_write_tags

### DIFF
--- a/R/forsys_run.R
+++ b/R/forsys_run.R
@@ -311,7 +311,7 @@ run <- function(
       stands_out_w <- stands_out_w %>% 
         left_join(join_y, by = stand_id_field) %>%
         bind_cols(priority_write_tags) %>%
-        bind_cols(scenario_write_tags)
+        bind_cols(scenario_write_tags := scenario_write_tags)
 
       # summarize project by subset
       summary_dat <- summarize_projects(


### PR DESCRIPTION
I noticed that an additional column is being created in the output but no name is being assigned to it, resulting in an unnamed column (subsequently labeled `...14` or similar).

This small addition instead calls the column `scenario_write_tags`. PTAL and let me know if you think this could work.